### PR TITLE
Fix process path 

### DIFF
--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ program
   .option('-o, --output [file]', 'Save output file to [file]')
   .option('-p, --print', 'Print result to stdout')
   .action(function (file) {
-    const url = file => new URL(join('file://', join(__dirname, file)))
+    const url = file => new URL(join('file://', join(process.cwd(), file)))
     const sourceCode = fs.readFileSync(url(file), 'utf8')
 
     const output = convert(sourceCode)


### PR DESCRIPTION
This fixes a bug where the path the program was looking in was relative to the install directory of the binary, eg %PROJECT_DIRECTORY%\node_modules\p5-global2instance\. Using the process.cwd() argument resolves this issue, meaning you can run this command from anywhere when installed globally.

[The following stackoverflow](https://stackoverflow.com/a/12239689/5176864) can be consulted for explanation:
